### PR TITLE
fix(xmind2xmindmark): fix indentation error when converting xmind to xmindmark

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -23,8 +23,8 @@
     </header>
     <div id="body">
       <div id="content">
-        <input type="file" name="file-select" id="file-select" accept=".xmindmark,.md,.txt" style="display: none;" />
-        <label id="file-select-handler" for="file-select">Choose a <code>.xmindmark</code> / <code>.md</code> / <code>.txt</code> file</label>
+        <input type="file" name="file-select" id="file-select" accept=".xmind,.xmindmark,.md,.txt" style="display: none;" />
+        <label id="file-select-handler" for="file-select">Choose a <code>.xmind</code> / <code>.xmindmark</code> / <code>.md</code> / <code>.txt</code> file</label>
         <div>Or directly edit your minds below:</div>
         <div id="input"></div>
       </div>

--- a/playground/src/loader.ts
+++ b/playground/src/loader.ts
@@ -1,10 +1,25 @@
+import { parseXMindToXMindMarkFile } from '../../src'
+
 export async function loadFileAsText(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const fileReader = new FileReader()
-    fileReader.addEventListener('loadend', () => resolve(fileReader.result as string))
     fileReader.addEventListener('error', reject)
     fileReader.addEventListener('abort', reject)
-    fileReader.readAsText(file)
+    const suffix = file.name.split('.').slice(-1)[0]
+    if (suffix === 'xmind') {
+      fileReader.readAsArrayBuffer(file)
+      fileReader.addEventListener('loadend', async () => {
+        const content = await parseXMindToXMindMarkFile(fileReader.result as ArrayBuffer);
+        if (content) {
+          resolve(content)
+        } else {
+          reject(new Error('Not valid .xmind file.'))
+        }
+      })
+    } else {
+      fileReader.readAsText(file)
+      fileReader.addEventListener('loadend', () => resolve(fileReader.result as string))
+    }
   })
 }
 

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -19,7 +19,7 @@ export const resetCommand = new Command('reset')
 
 export async function fromActionHandler(xmindFilePath: string, outputFilePath: string | undefined) {
   const xmindFile = readFileSync(xmindFilePath)
-  const xmindmarkContent = await parseXMindToXMindMarkFile(xmindFile)
+  const xmindmarkContent = await parseXMindToXMindMarkFile(xmindFile.buffer as ArrayBuffer);
 
   if (outputFilePath) {
     let outputPath = resolve(outputFilePath)
@@ -44,7 +44,7 @@ export const fromCommand = new Command('from')
   .description('Generate .xmindmark file from other types of file')
   .action(fromActionHandler)
 
-export async function mainActionHandler(files: string[], options: CLIOptions, command: Command) {  
+export async function mainActionHandler(files: string[], options: CLIOptions, command: Command) {
   if (files.length === 0) command.help()
 
   const { format, outputDir } = options

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { parseXMindMarkToXMindFile } from './lib/xmindmark-to-xmind'
+export { parseXMindToXMindMarkFile } from './lib/xmind-to-xmindmark'

--- a/src/lib/xmind-to-xmindmark.ts
+++ b/src/lib/xmind-to-xmindmark.ts
@@ -143,7 +143,8 @@ function isOrderInsideRange(range: ClosedRange, order: number): boolean {
 }
 
 function makeIndentOfLine({ depth }: Pick<TopicScope, 'depth'>): string {
-  return Array.from({ length: depth }).reduce<string>(prevIndent => prevIndent.concat('    '), '')
+  return depth <= 1 ?
+    '' : Array.from({ length: depth - 1 }).reduce<string>(prevIndent => prevIndent.concat('    '), '')
 }
 
 function makePrefixOfLine({ depth, type }: TopicScope): string {
@@ -225,7 +226,7 @@ function makeIdentifyBoundaries(topic: TopicModel): Boundary[] {
 
   if (topic.boundaries.length === 1) return [{ ...topic.boundaries[0], identifier: 'B' }]
 
-  return topic.boundaries.map((boundary, i) => ({ ...boundary, identifier: `B${i + 1}`}))
+  return topic.boundaries.map((boundary, i) => ({ ...boundary, identifier: `B${i + 1}` }))
 }
 
 function makeIdentifySummaries(topic: TopicModel): Summary[] {
@@ -237,7 +238,7 @@ function makeIdentifySummaries(topic: TopicModel): Summary[] {
     && topic.children.summary.length === topic.summaries.length
   ) {
     const summaries = topic.summaries.map((summary, i) => {
-      const title = topic.children!.summary?.find(({ id }) => id === summary.topicId )?.title
+      const title = topic.children!.summary?.find(({ id }) => id === summary.topicId)?.title
 
       return typeof title !== 'undefined'
         ? { ...summary, title, identifier: `S${i + 1}` }

--- a/src/tests/xmind-to-xmindmark.sample.ts
+++ b/src/tests/xmind-to-xmindmark.sample.ts
@@ -511,32 +511,32 @@ export const inputJSON = [
 
 export const expectedOutputXMindMark = 
 `Central Topic
-    - Main Topic 1 [^1]
-        - Subtopic 1 [2]
-            - Subtopic 1 [B1]
-            - Subtopic 2 [B1][B2]
-            - Subtopic 3 [B2]
-            [B1]: title1
-            [B2]: title2
-        - Subtopic 2
-        - Subtopic 3 [^2]
-            - Subtopic 1 [B]
-            - Subtopic 2 [B]
-            - Subtopic 3 [B]
-            [B]: title2
-    - Main Topic 2 [1]
-    - Main Topic 3
-        - Subtopic 1
-            - Subtopic 1 [^3][S1]
-            - Subtopic 2 [B][S1][S2]
-            - Subtopic 3 [B][S1][S2]
-            - Subtopic 4 [S2]
-            [S1]: Summary 1
-                - Subtopic 1
-                - Subtopic 2
-                - Subtopic 3
-            [S2]: Summary 2
-        - Subtopic 2
-        - Subtopic 3
-    - Main Topic 4 [3]
+- Main Topic 1 [^1]
+    - Subtopic 1 [2]
+        - Subtopic 1 [B1]
+        - Subtopic 2 [B1][B2]
+        - Subtopic 3 [B2]
+        [B1]: title1
+        [B2]: title2
+    - Subtopic 2
+    - Subtopic 3 [^2]
+        - Subtopic 1 [B]
+        - Subtopic 2 [B]
+        - Subtopic 3 [B]
+        [B]: title2
+- Main Topic 2 [1]
+- Main Topic 3
+    - Subtopic 1
+        - Subtopic 1 [^3][S1]
+        - Subtopic 2 [B][S1][S2]
+        - Subtopic 3 [B][S1][S2]
+        - Subtopic 4 [S2]
+        [S1]: Summary 1
+            - Subtopic 1
+            - Subtopic 2
+            - Subtopic 3
+        [S2]: Summary 2
+    - Subtopic 2
+    - Subtopic 3
+- Main Topic 4 [3]
 `


### PR DESCRIPTION
## Issue Description

According to the [xmindmark syntax](https://github.com/xmindltd/xmindmark/blob/main/docs/specification.md) documentation, the correct format for `.xmindmark` text should be:

```
Central Topic
- Main Topic 1
- Main Topic 2
```

I use the command `xmindmark -f xmind example.xmindmark` to generate the `example.xmind` file, which is a valid `.xmind` file.

---

However, when I use the command `xmindmark from example.xmind`, the generated `example.xmindmark` content has the following format:

```sh
$ xmindmark from example.xmind
Central Topic
    - Main Topic 1
    - Main Topic 2
```

<img alt="Incorrect Xmindmark Syntax" src="https://github.com/user-attachments/assets/be9becda-45bb-4041-b905-20d18467d781" />

When I attempt to convert `example.xmindmark` back to `example.xmind` using the `xmindmark` command, a parsing error occurs:

```sh
$ xmindmark -f xmind example.xmindmark
/Users/{me}/.nvm/versions/node/v22.11.0/lib/node_modules/xmindmark/dist/src/parser/mindmap.js:229
    parentObject = parentObject.rootTopic || parentObject;
                                ^

TypeError: Cannot read properties of undefined (reading 'rootTopic')
    at addTopic (/Users/{me}/.nvm/versions/node/v22.11.0/lib/node_modules/xmindmark/dist/src/parser/mindmap.js:229:33)
    at addLine (/Users/{me}/.nvm/versions/node/v22.11.0/lib/node_modules/xmindmark/dist/src/parser/mindmark.js:69:65)
    at /Users/{me}/.nvm/versions/node/v22.11.0/lib/node_modules/xmindmark/dist/src/parser/mindmark.js:146:62
    at Array.forEach (<anonymous>)
    at createMapByXMindMark (/Users/{me}/.nvm/versions/node/v22.11.0/lib/node_modules/xmindmark/dist/src/parser/mindmark.js:146:46)
    at /Users/{me}/.nvm/versions/node/v22.11.0/lib/node_modules/xmindmark/dist/src/lib/xmindmark-to-xmind.js:34:64
    at Generator.next (<anonymous>)
    at /Users/{me}/.nvm/versions/node/v22.11.0/lib/node_modules/xmindmark/dist/src/lib/xmindmark-to-xmind.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/{me}/.nvm/versions/node/v22.11.0/lib/node_modules/xmindmark/dist/src/lib/xmindmark-to-xmind.js:4:12)
```

**Root Cause**: The indentation handling in `src/lib/xmind-to-xmindmark.ts` is incorrect, causing the generated `example.xmindmark` file to deviate from the standard xmindmark syntax. Additionally, the original unit tests were also flawed.

## Solution

Modify the indentation logic in `src/lib/xmind-to-xmindmark.ts`.
